### PR TITLE
Added Support for Apple GPUs

### DIFF
--- a/BlendPresence/__init__.py
+++ b/BlendPresence/__init__.py
@@ -40,6 +40,7 @@ class bpi:
         blendGPU = bpy.context.preferences.addons['cycles'].preferences.devices[0].name
     elif bpy.app.version[0] >= 3 and bpy.app.version[1] >= 0:
         blendGPU = gpu.platform.renderer_get()
+        VendorStr = gpu.platform.vendor_get()
     else:
         blendGPU = ""
         print("[BP] This version of Blender does not support 'Display GPU'.")
@@ -219,6 +220,7 @@ def updatePresence():
 
         if prefs.displayGPU:
             gpustr = bpi.blendGPU
+            gpuVendor = bpi.VendorStr
             if gpustr and "NVIDIA GeForce" in gpustr:
                 gpustr = gpustr.replace("NVIDIA GeForce ","")
                 gpustr = gpustr.split("/", 1)[0]
@@ -229,9 +231,9 @@ def updatePresence():
             elif gpustr and "Radeon" in gpustr:
                 gpustr = gpustr.split("/", 1)[0]
                 largeIconText = largeIconText + " | " + gpustr
-            elif gpustr and "Metal" in gpustr:
-                gpustr = gpustr.split("/", 1)[0]
-                largeIconText = largeIconText + " | " + gpustr
+            elif gpuVendor and "Apple" in gpuVendor:
+                gpuVendor = gpuVendor.split("/", 1)[0]
+                largeIconText = largeIconText + " | " + gpuVendor
 
         # SMALL ICON
         if prefs.displaySmallIcon:

--- a/BlendPresence/__init__.py
+++ b/BlendPresence/__init__.py
@@ -229,6 +229,9 @@ def updatePresence():
             elif gpustr and "Radeon" in gpustr:
                 gpustr = gpustr.split("/", 1)[0]
                 largeIconText = largeIconText + " | " + gpustr
+            elif gpustr and "Metal" in gpustr:
+                gpustr = gpustr.split("/", 1)[0]
+                largeIconText = largeIconText + " | " + gpustr
 
         # SMALL ICON
         if prefs.displaySmallIcon:


### PR DESCRIPTION
Since using `gpu.platform.renderer_get()` does not work on apple devices: it just returns "Metal API", I utilized `gpu.platform.vendor_get()` in order to get the actual name of the GPU